### PR TITLE
set_include_path: Not delete system include path

### DIFF
--- a/includes/basics.php
+++ b/includes/basics.php
@@ -30,6 +30,7 @@ set_include_path(
     implode(
         PATH_SEPARATOR,
         array(
+            get_include_path(),
             realpath(APPLICATION_PATH . '/libraries/zendframework/zendframework1/library/'),
         )
     )


### PR DESCRIPTION
FIXES
Warning:  parse_ini_file(config.ini) [function.parse-ini-file]: failed to open stream: No such file or directory in /srv/www/htdocs/kimai-0.9.3/includes/kspi.php on line 48

Changes proposed in this pull request:
- set_include_path should not delete system default include paths.

Reason for this pull request:
-  In my case my path "/usr/share/php:/usr/share/pear" was dropped by the old call of set_include_path.
